### PR TITLE
Create docker build environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM andrewdotnich/docker-gcc7-i686-elf as builder
+
+RUN apt-get update
+RUN apt-get install -y curl gnupg2
+
+RUN curl -sSL https://dist.crystal-lang.org/apt/setup.sh | bash
+RUN echo 'deb https://dist.crystal-lang.org/apt crystal main' > /etc/apt/sources.list.d/crystal.list
+
+RUN apt-get update && \
+    apt-get install -y crystal  scons \
+    nasm grub-pc-bin mtools xorriso
+
+RUN mkdir -p /build
+
+VOLUME /build
+WORKDIR /build
+
+ENTRYPOINT ["scons"]

--- a/README.md
+++ b/README.md
@@ -17,6 +17,15 @@ We'll be happy to work with you.
 - Run `scons test` to run Runtime tests.
 - Run `scons --qemu-curses` to build and run qemu
 
+## Building via Docker
+
+- Build the Docker image: `docker build -t fluorite-builder .`
+- Use the image to compile the code: `docker run --rm -v $(pwd):/build -t fluorite-builder`
+- Any arguments to `scons` can be passed in like this:
+  `docker run --rm -v $(pwd):/build -t fluorite-builder -- test` <- runs `scons test` within the container.
+
+- all build artifacts will be placed in the `./build` directory
+
 ## Troubleshooting
 
 **`xorriso : FAILURE : Cannot find path '/efi.img' in loaded ISO image`** `or`   


### PR DESCRIPTION
Configuring and installing cross-compilers can be an intimidating task, so this helps lower the barrier to entry.

Instructions are in the README, but essentially:

- the container has all the tools
- the user mounts the repo as a volume in the container, and then runs the build tools
- the container finishes, with the build artefacts in the same place they would be if the user had run them on their machine natively.